### PR TITLE
fix: change application name NoteCLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
-# Document Management System (DMS)
+# Notepad Command Line Base (NoteCLI)
 
-A command-line based Document Management System written in C that allows users to create, read, update, and delete text documents organized in categories. The system includes automatic versioning and comprehensive operation logging.
+A command-line based notepad app written in C that allows users to create, read, update, and delete textfile organized in categories. The system includes automatic versioning and comprehensive operation logging.
 
 ## Features
 
-- Create new text documents in different categories
-- Read existing documents
-- Update document content with automatic version backup
-- Delete documents
+- Create new text textfile in different categories
+- Read existing textfile
+- Update textfile content with automatic version backup
+- Delete textfile
 - Organized file structure with categories
-- Version history for edited documents
+- Version history for edited textfile
 - Complete operation logging with timestamps
 - Error handling and input validation
 - Color-coded console output
-- Clean all documents with history preservation
+- Clean all textfile with history preservation
 
 ## Directory Structure
 
 ```
-DocumentManager/
+NoteCLI/
 ├── bin/               # Compiled binary
 ├── src/               # Source code files
 ├── include/           # Header files
-├── data/              # Document storage
-│   ├── recipes/       # Recipe documents
-│   ├── notes/         # Note documents
+├── data/              # textfile storage
+│   ├── recipes/       # Recipe textfile 
+│   ├── notes/         # Note textfile 
 │   ├── logs/          # Operation logs and history
 │   │   └── history.txt    # Complete operation history
 │   └── versions/      # Automatically saved old versions
@@ -47,7 +47,7 @@ To clean the build files:
 make clean
 ```
 
-To clean all documents while preserving history:
+To clean all textfile while preserving history:
 
 ```bash
 make clean-docs
@@ -55,7 +55,7 @@ make clean-docs
 
 This will:
 1. Ask for confirmation before proceeding
-2. Remove all documents in notes, recipes, and versions directories
+2. Remove all textfile in notes, recipes, and versions directories
 3. Preserve the operation history in data/logs/history.txt
 4. Log the cleanup operation with timestamp
 
@@ -66,29 +66,29 @@ This will:
 The DMS supports the following commands:
 
 ```bash
-# Create a new document
+# Create a new textfile
 ./bin/dms create <category> <filename>
 
-# Read a document
+# Read a textfile
 ./bin/dms read <category> <filename>
 
-# Update a document
+# Update a textfile
 ./bin/dms update <category> <filename>
 
-# Delete a document
+# Delete a textfile
 ./bin/dms delete <category> <filename>
 ```
 
 ### Available Categories
-The system organizes documents into these categories:
+The system organizes textfile into these categories:
 - `recipes` - For storing cooking recipes
 - `notes` - For general notes and todos
 - `logs` - For logs and records
 
 ### How to Use
 
-#### 1. Creating Documents
-There are two ways to create documents:
+#### 1. Creating textfile
+There are two ways to create textfile:
 
 a. Interactive Mode:
 ```bash
@@ -101,14 +101,14 @@ b. Using Echo (for quick creation):
 echo "My content here" | ./bin/dms create notes quick-note.txt
 ```
 
-#### 2. Reading Documents
-To read any document:
+#### 2. Reading textfile
+To read any textfile:
 ```bash
 ./bin/dms read notes todo.txt
 ```
 
-#### 3. Updating Documents
-When you update a document, the old version is automatically saved in the versions directory:
+#### 3. Updating textfile
+When you update a textfile, the old version is automatically saved in the versions directory:
 
 a. Interactive Mode:
 ```bash
@@ -123,8 +123,8 @@ echo "Updated content" | ./bin/dms update notes todo.txt
 
 The old version will be saved as: `data/versions/notes_YYYYMMDD_HHMMSS_todo.txt`
 
-#### 4. Deleting Documents
-To delete a document (will ask for confirmation):
+#### 4. Deleting textfile
+To delete a textfile (will ask for confirmation):
 ```bash
 ./bin/dms delete notes todo.txt
 ```
@@ -143,7 +143,7 @@ Example log entries:
 [2025-05-24 20:56:07] READ: notes/todo.txt
 [2025-05-24 20:56:15] UPDATE: notes/todo.txt
 [2025-05-24 20:56:19] DELETE: notes/todo.txt
-[2025-05-24 21:00:00] CLEAN-DOCS: All documents cleared (notes, recipes, versions)
+[2025-05-24 21:00:00] CLEAN-DOCS: All textfiles cleared (notes, recipes, versions)
 ```
 
 To view the operation history:
@@ -153,7 +153,7 @@ cat data/logs/history.txt
 
 ### Version Control
 
-- All document updates are automatically versioned
+- All textfile updates are automatically versioned
 - Old versions are stored in `data/versions/`
 - Version files are named using the format: `category_YYYYMMDD_HHMMSS_filename`
 - You can access old versions directly in the versions directory
@@ -202,7 +202,7 @@ echo "1. Buy groceries - DONE
   - Hyphens (-)
   - Underscores (_)
 - Directory traversal is not allowed in filenames
-- Maximum input size for document content is 4KB
+- Maximum input size for textfile content is 4KB
 
 ### Error Handling
 
@@ -220,11 +220,11 @@ The system provides clear error messages for:
 ### Tips
 
 1. Use meaningful filenames that describe the content
-2. Check the versions directory for document history
+2. Check the versions directory for textfile history
 3. Review the operation history in `data/logs/history.txt` to track all actions
 4. Use the appropriate category for better organization
 5. Make sure to press Ctrl+D after entering content in interactive mode
 6. For multiline content, using echo with newlines (\n) is recommended
-7. Check both version backups and operation logs for complete document history 
+7. Check both version backups and operation logs for complete textfile history 
 
 -->


### PR DESCRIPTION
# NoteCLI

To avoid confusion caused by varying interpretations of 'Document Manager', we've renamed it to 'NoteCLI' for clearer identity and purpose. 